### PR TITLE
Remove grant as a facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -83,7 +83,6 @@ class CatalogController < ApplicationController
     config.add_facet_field 'division_ssim', label: 'Division'
     config.add_facet_field 'university_ssim', label: 'University'
     config.add_facet_field 'agent_ssim', label: 'Agent'
-    config.add_facet_field 'grant_ssim', label: 'Grant'
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request


### PR DESCRIPTION
Per our planning meeting on 2018-06-31, Peter said we could remove this
as there would be too many values for this to be a useful facet.