### PR TITLE
Encode the id for a URI

### DIFF
--- a/app/javascript/blacklight/layouts/showPage.vue
+++ b/app/javascript/blacklight/layouts/showPage.vue
@@ -21,7 +21,7 @@ export default {
     }
   },
   created() {
-    const endpoint = `/catalog/${this.$route.params.id}`
+    const endpoint = `/catalog/${encodeURIComponent(this.$route.params.id)}`
     this.$http.get(endpoint).then(function(response){
         this.result = response.data
         this.message = null


### PR DESCRIPTION
Because the identifier itself could be a URI, we need to encode slashes
as `%2F`, etc.