### PR TITLE
Do not pad end pagination label by 1

### DIFF
--- a/app/javascript/blacklight/pagination.vue
+++ b/app/javascript/blacklight/pagination.vue
@@ -27,7 +27,7 @@ export default {
       return this.pages.offset_value + 1
     },
     end: function() {
-      return Math.min(this.start + this.pages.limit_value, this.pages.total_count)
+      return Math.min(this.pages.offset_value + this.pages.limit_value, this.pages.total_count)
     },
     totalCount: function() {
       return this.pages.total_count


### PR DESCRIPTION
Else you see `1 - 11 of 72`, `11 - 21 of 72` because we included the +1 from the start value (*e.g.*, `1`, `11`) instead of the bare offset value (*e.g.*, `0`, `10`).